### PR TITLE
Bump version for new release

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
-authors = ["claresinger <csinger@caltech.edu>"]
-version = "0.1.0"
+authors = ["Climate Modeling Alliance"]
+version = "0.2.0"
 
 [deps]
 CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"


### PR DESCRIPTION
We are depending on Insolation master in ClimaAtmos, and we need to be able to upgrade to a released version that is compatible with the latest version of CLIMAParameters.