### PR TITLE
Use new way of handling clima parameters

### DIFF
--- a/.github/workflows/CodeCov.yml
+++ b/.github/workflows/CodeCov.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Set up Julia
       uses: julia-actions/setup-julia@latest
       with:
-        version: 1.5.4
+        version: 1.7.3
 
     - name: Test with coverage
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5.4'
+          - '1.7.3'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -16,7 +16,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: julia-actions/setup-julia@latest
         with:
-          version: 1.5.4
+          version: 1.7.3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "0.2.1"
+version = "0.3.0"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/Project.toml
+++ b/Project.toml
@@ -4,11 +4,9 @@ authors = ["Climate Modeling Alliance"]
 version = "0.2.1"
 
 [deps]
-CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 
 [compat]
-julia = "1.5, 1.7"
-CLIMAParameters = "0.1.10, 0.4, 0.5, 0.6"
+julia = "1.7"

--- a/bors.toml
+++ b/bors.toml
@@ -1,7 +1,7 @@
 status = [
-  "ci 1.5.4 - ubuntu-latest",
-  "ci 1.5.4 - windows-latest",
-  "ci 1.5.4 - macOS-latest",
+  "ci 1.7.3 - ubuntu-latest",
+  "ci 1.7.3 - windows-latest",
+  "ci 1.7.3 - macOS-latest",
   "docbuild",
 ]
 delete_merged_branches = true

--- a/docs/src/InsolationExamples.md
+++ b/docs/src/InsolationExamples.md
@@ -24,16 +24,18 @@ diurnal_cycle(lat, lon, date, timezone, "Finland_June.png")
 ## Daily-mean insolation
 ### Insolation in J2000
 ```@example
-using CLIMAParameters
-using CLIMAParameters.Planet
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import Insolation
+import Insolation.Parameters as IP
+
+FT = Float64
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
 
 include("plot_insolation.jl")
 
-γ0 = obliq_epoch(param_set)
-ϖ0 = lon_perihelion_epoch(param_set)
-e0 = eccentricity_epoch(param_set)
+γ0 = IP.obliq_epoch(param_set)
+ϖ0 = IP.lon_perihelion_epoch(param_set)
+e0 = IP.eccentricity_epoch(param_set)
 
 days, lats, F0 = calc_day_lat_insolation(365, 180, param_set)
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ0), rad2deg(ϖ0), e0) #hide
@@ -43,19 +45,22 @@ plot_day_lat_insolation(days, lats, F0, "YlOrRd", title, "insol_example1.png")
 
 ### Insolation with smaller obliquity
 ```@example
-using CLIMAParameters # hide
-using CLIMAParameters.Planet # hide
-struct EarthParameterSet <: AbstractEarthParameterSet end # hide
-const param_set = EarthParameterSet() # hide
+import Insolation
+import Insolation.Parameters as IP
+
+FT = Float64
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
+
 include("plot_insolation.jl") # hide
-γ0 = obliq_epoch(param_set) # hide
-ϖ0 = lon_perihelion_epoch(param_set) # hide
-e0 = eccentricity_epoch(param_set) # hide
+γ0 = IP.obliq_epoch(param_set) # hide
+ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
+e0 = IP.eccentricity_epoch(param_set) # hide
 days, lats, F0 = calc_day_lat_insolation(365, 180, param_set) # hide
 
 # decrease γ to 20.0°
-CLIMAParameters.Planet.obliq_epoch(::EarthParameterSet) = deg2rad(20.0)
-γ1 = obliq_epoch(param_set)
+param_set = create_insolation_parameters(FT, (;obliq_epoch = deg2rad(20.0)))
+γ1 = IP.obliq_epoch(param_set)
 days, lats, F2 = calc_day_lat_insolation(365, 180, param_set)
 
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ1), rad2deg(ϖ0), e0) # hide
@@ -68,19 +73,22 @@ plot_day_lat_insolation(days, lats, F2-F0, "PRGn", title, "insol_example2b.png")
 
 ### Insolation with very large obliquity (like Uranus)
 ```@example
-using CLIMAParameters # hide
-using CLIMAParameters.Planet # hide
-struct EarthParameterSet <: AbstractEarthParameterSet end # hide
-const param_set = EarthParameterSet() # hide
+import Insolation
+import Insolation.Parameters as IP
+
+FT = Float64
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
+
 include("plot_insolation.jl") # hide
-γ0 = obliq_epoch(param_set) # hide
-ϖ0 = lon_perihelion_epoch(param_set) # hide
-e0 = eccentricity_epoch(param_set) # hide
+γ0 = IP.obliq_epoch(param_set) # hide
+ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
+e0 = IP.eccentricity_epoch(param_set) # hide
 days, lats, F0 = calc_day_lat_insolation(365, 180, param_set) # hide
 
 # now change obliquity to 97.86°
-CLIMAParameters.Planet.obliq_epoch(::EarthParameterSet) = deg2rad(97.86)
-γ4 = obliq_epoch(param_set)
+param_set = create_insolation_parameters(FT, (;obliq_epoch = deg2rad(97.86)))
+γ4 = IP.obliq_epoch(param_set)
 days, lats, F5 = calc_day_lat_insolation(365, 180, param_set)
 
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ4), rad2deg(ϖ0), e0) # hide

--- a/docs/src/find_equinox_perihelion_dates.jl
+++ b/docs/src/find_equinox_perihelion_dates.jl
@@ -2,10 +2,11 @@ using Insolation
 using Plots
 using Dates
 
-using CLIMAParameters
-using CLIMAParameters.Planet
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import CLIMAParameters as CP
+
+FT = Float64
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
 
 # Difference in NH and SH zenith angles at time x in given year
 function zdiff(x, year)
@@ -18,7 +19,7 @@ end
 # x is date relative to March 1, with 1.00 representing March 1 00:00
 function xtomarchdate(x, year)
     basedate = Dates.DateTime(year, 3, 1)
-    deltat = Dates.Second(round((x-1)*Planet.day(param_set)))
+    deltat = Dates.Second(round((x-1)*IP.day(param_set)))
     return basedate + deltat
 end
 
@@ -26,13 +27,13 @@ end
 function edist(x, year)
     date = xtojandate(x,year)
     _, dist = daily_zenith_angle(date, 0., param_set, milankovitch=true)
-    return dist/orbit_semimaj(param_set)
+    return dist/IP.orbit_semimaj(param_set)
 end
 
 # x is date relative to Jan 1, with 1.00 representing Jan 1 00:00
 function xtojandate(x, year)
     basedate = Dates.DateTime(year, 1, 1)
-    deltat = Dates.Second(round((x-1)*Planet.day(param_set)))
+    deltat = Dates.Second(round((x-1)*IP.day(param_set)))
     date = basedate + deltat
     return date
 end

--- a/docs/src/plot_diurnal_cycle.jl
+++ b/docs/src/plot_diurnal_cycle.jl
@@ -4,13 +4,11 @@ using Dates
 using Statistics
 using Formatting
 
-using CLIMAParameters
-using CLIMAParameters.Planet
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
+import CLIMAParameters as CP
 
-using CLIMAParameters: AbstractParameterSet
-const APS = AbstractParameterSet
+FT = Float64
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
 
 function diurnal_cycle(lat, lon, date, timezone, filename)
     nhours = 1000

--- a/docs/src/plot_insolation.jl
+++ b/docs/src/plot_insolation.jl
@@ -4,17 +4,17 @@ using Dates
 using Statistics
 using Formatting
 
-using CLIMAParameters: AbstractParameterSet
-const APS = AbstractParameterSet
+import CLIMAParameters as CP
+import Insolation.Parameters as IP
 
 """
     calc_day_lat_insolation(n_days::I,
                             n_lats::I,
-                            param_set::APS) where {I<:Int}
+                            param_set::IP.AIP) where {I<:Int}
 """
 function calc_day_lat_insolation(n_days::I,
                                 n_lats::I,
-                                param_set::APS) where {I<:Int}
+                                param_set::IP.AIP) where {I<:Int}
   d_arr = Array{I}(round.(collect(range(0, stop = 365, length = n_days))))
   l_arr = collect(range(-90, stop = 90, length = n_lats))
   F_arr = zeros(n_days, n_lats)

--- a/parameters/create_parameters.jl
+++ b/parameters/create_parameters.jl
@@ -1,0 +1,11 @@
+import CLIMAParameters as CP
+import Insolation.Parameters as IP
+
+function create_insolation_parameters(FT, overrides::NamedTuple = NamedTuple())
+    toml_dict = CP.create_toml_dict(FT; dict_type = "alias")
+    aliases = string.(fieldnames(IP.InsolationParameters))
+    pairs = CP.get_parameter_values!(toml_dict, aliases, "Insolation")
+    params = merge((;pairs...), overrides) # overrides
+    param_set = IP.InsolationParameters{FT}(; params...)
+    return param_set
+end

--- a/src/Insolation.jl
+++ b/src/Insolation.jl
@@ -1,10 +1,10 @@
 module Insolation
 
 using Dates, DelimitedFiles, Interpolations
-using CLIMAParameters
-using CLIMAParameters.Planet
-using CLIMAParameters: AbstractParameterSet
-const APS = AbstractParameterSet
+
+include("Parameters.jl")
+import .Parameters as IP
+const AIP = IP.AbstractInsolationParams
 
 export orbital_params
 

--- a/src/InsolationCalc.jl
+++ b/src/InsolationCalc.jl
@@ -1,14 +1,14 @@
 export insolation, solar_flux_and_cos_sza
 
 """
-    insolation(θ::FT, d::FT, param_set::APS) where {FT <: Real}
+    insolation(θ::FT, d::FT, param_set::IP.AIP) where {FT <: Real}
 
 Returns the insolation given the zenith angle and earth-sun distance
 param_set is an AbstractParameterSet from CLIMAParameters.jl.
 """
-function insolation(θ::FT, d::FT, param_set::APS) where {FT <: Real}
-    S0::FT = tot_solar_irrad(param_set)
-    d0::FT = orbit_semimaj(param_set)
+function insolation(θ::FT, d::FT, param_set::IP.AIP) where {FT <: Real}
+    S0::FT = IP.tot_solar_irrad(param_set)
+    d0::FT = IP.orbit_semimaj(param_set)
     # set max. zenith angle to π/2, insolation should not be negative
     if θ > FT(π)/2
         θ = FT(π)/2
@@ -24,7 +24,7 @@ end
     solar_flux_and_cos_sza(date::DateTime,
                       longitude::FT,
                       latitude::FT,
-                      param_set::APS) where {FT <: Real}
+                      param_set::IP.AIP) where {FT <: Real}
 
 Returns the top-of-atmosphere (TOA) solar flux, i.e. 
 the total solar irradiance (TSI) weighted by the earth-sun distance
@@ -34,9 +34,9 @@ param_set is an AbstractParameterSet from CLIMAParameters.jl.
 function solar_flux_and_cos_sza(date::DateTime,
                            longitude::FT,
                            latitude::FT,
-                           param_set::APS) where {FT <: Real}
-    S0::FT = tot_solar_irrad(param_set)
-    d0::FT = orbit_semimaj(param_set)
+                           param_set::IP.AIP) where {FT <: Real}
+    S0::FT = IP.tot_solar_irrad(param_set)
+    d0::FT = IP.orbit_semimaj(param_set)
     # θ = solar zenith angle, ζ = solar azimuth angle, d = earth-sun distance
     θ, ζ, d = instantaneous_zenith_angle(date, longitude, latitude, param_set)
     # set max. zenith angle to π/2, insolation should not be negative

--- a/src/Parameters.jl
+++ b/src/Parameters.jl
@@ -1,0 +1,23 @@
+module Parameters
+
+abstract type AbstractInsolationParams end
+const AIP = AbstractInsolationParams
+
+Base.@kwdef struct InsolationParameters{FT} <: AbstractInsolationParams
+    year_anom::FT
+    day::FT
+    orbit_semimaj::FT
+    tot_solar_irrad::FT
+    epoch::FT
+    mean_anom_epoch::FT
+    eccentricity_epoch::FT
+    obliq_epoch::FT
+    lon_perihelion_epoch::FT
+end
+
+# Method wrappers
+for var in fieldnames(InsolationParameters)
+    @eval $var(ps::AIP) = ps.$var
+end
+
+end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,4 +1,5 @@
 [deps]
+CLIMAParameters = "6eacf6c3-8458-43b9-ae03-caf5306d3d53"
 Optim = "429524aa-4258-5aef-a3af-852621145aeb"
 Roots = "f2b01f46-fcfa-551c-844a-d8ac1e96c665"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -8,12 +8,13 @@ using Statistics
 using Roots
 using Optim
 
-using CLIMAParameters
-using CLIMAParameters.Planet
-struct EarthParameterSet <: AbstractEarthParameterSet end
-const param_set = EarthParameterSet()
-
+import CLIMAParameters as CP
+import Insolation.Parameters as IP
 FT = Float32
+
+include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
+param_set = create_insolation_parameters(FT)
+
 @testset "Orbital Params" begin
     include("test_orbit_param.jl")
 end
@@ -32,6 +33,8 @@ end
 end
 
 FT = Float64
+param_set = create_insolation_parameters(FT)
+
 @testset "Orbital Params" begin
     include("test_orbit_param.jl")
 end

--- a/test/test_equinox.jl
+++ b/test/test_equinox.jl
@@ -9,7 +9,7 @@ end
 # x is date relative to March 1, with 1.00 representing March 1 00:00
 function xtomarchdate(x, year)
     basedate = Dates.DateTime(year, 3, 1)
-    deltat = Dates.Second(round((x-1)*Planet.day(param_set)))
+    deltat = Dates.Second(round((x-1)*IP.day(param_set)))
     return basedate + deltat
 end
 

--- a/test/test_insolation.jl
+++ b/test/test_insolation.jl
@@ -11,7 +11,7 @@ F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
 S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
-@test S ≈ tot_solar_irrad(param_set) rtol=rtol_insol
+@test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
 # polar night NH 1
@@ -22,7 +22,7 @@ F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
 S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
-@test S ≈ tot_solar_irrad(param_set) rtol=rtol_insol
+@test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
 # polar night NH 2
@@ -32,7 +32,7 @@ F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
 S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
-@test S ≈ tot_solar_irrad(param_set) rtol=rtol_insol
+@test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
 ## Test symmetry of insolation at equinox
@@ -65,11 +65,11 @@ end
 zonal_mean_insol = mean(F_arr, dims=1)
 area_fac = abs.(cosd.(l_arr))
 global_mean_insol = sum(zonal_mean_insol * area_fac) / sum(area_fac)
-@test global_mean_insol ≈ tot_solar_irrad(param_set) / 4 rtol=rtol
+@test global_mean_insol ≈ IP.tot_solar_irrad(param_set) / 4 rtol=rtol
 
 ## Test invariance of zonal-mean insolation under rotation of ϖ
-ϖ0 = lon_perihelion_epoch(param_set)
-CLIMAParameters.Planet.lon_perihelion_epoch(::EarthParameterSet) = ϖ0 + π
+ϖ0 = IP.lon_perihelion_epoch(param_set)
+param_set = create_insolation_parameters(FT, (; lon_perihelion_epoch = ϖ0 + π))
 
 for (i, d) in enumerate(d_arr)
     for (j, lat) in enumerate(l_arr)
@@ -82,4 +82,4 @@ end
 zonal_mean_insol_rotate = mean(F_arr, dims=1)
 @test zonal_mean_insol_rotate ≈ zonal_mean_insol rtol=rtol
 
-CLIMAParameters.Planet.lon_perihelion_epoch(::EarthParameterSet) = ϖ0
+param_set = create_insolation_parameters(FT, (; lon_perihelion_epoch = ϖ0))

--- a/test/test_orbit_param.jl
+++ b/test/test_orbit_param.jl
@@ -1,10 +1,10 @@
 rtol = 1e-2
 
-@test mod(Insolation.ϖ_spline(0.0),2π) ≈ mod(lon_perihelion_epoch(param_set),2π) rtol=rtol
-@test Insolation.γ_spline(0.0) ≈ obliq_epoch(param_set) rtol=rtol
-@test Insolation.e_spline(0.0) ≈ eccentricity_epoch(param_set) rtol=rtol
+@test mod(Insolation.ϖ_spline(0.0),2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
+@test Insolation.γ_spline(0.0) ≈ IP.obliq_epoch(param_set) rtol=rtol
+@test Insolation.e_spline(0.0) ≈ IP.eccentricity_epoch(param_set) rtol=rtol
 
 ϖ0, γ0, e0 = orbital_params(0.0)
-@test mod(ϖ0,2π) ≈ mod(lon_perihelion_epoch(param_set),2π) rtol=rtol
-@test γ0 ≈ obliq_epoch(param_set) rtol=rtol
-@test e0 ≈ eccentricity_epoch(param_set) rtol=rtol
+@test mod(ϖ0,2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
+@test γ0 ≈ IP.obliq_epoch(param_set) rtol=rtol
+@test e0 ≈ IP.eccentricity_epoch(param_set) rtol=rtol

--- a/test/test_perihelion.jl
+++ b/test/test_perihelion.jl
@@ -1,7 +1,7 @@
 # x is date relative to Jan 1, with 1.00 representing Jan 1 00:00
 function xtojandate(x, year)
     basedate = Dates.DateTime(year, 1, 1)
-    deltat = Dates.Second(round((x-1)*Planet.day(param_set)))
+    deltat = Dates.Second(round((x-1)*IP.day(param_set)))
     date = basedate + deltat
     return date
 end
@@ -10,7 +10,7 @@ end
 function edist(x, year)
     date = xtojandate(x,year)
     _, dist = daily_zenith_angle(date, FT(0), param_set)
-    return dist/orbit_semimaj(param_set)
+    return dist/IP.orbit_semimaj(param_set)
 end
 
 years = 1900:2100

--- a/test/test_zenith_angle.jl
+++ b/test/test_zenith_angle.jl
@@ -52,4 +52,4 @@ sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
 ## Test Distance
 date = Dates.DateTime(2000, 3, 22, 0, 0, 0)
 sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
-@test d ≈ orbit_semimaj(param_set) rtol=rtol
+@test d ≈ IP.orbit_semimaj(param_set) rtol=rtol


### PR DESCRIPTION
This PR upgrades Insolation.jl to use the new way of handling clima parameters, by:
 - Defining a `InsolationParameters` struct that has its own parameters, and populating them via a toml dictionary from CLIMAParameters. As a result, Insolation.jl (like all other packages) no longer needs to depend on CLIMAParameters. Our test, examples, and docs directory may still need to depend on CLIMAParameters in order to test the package with values from CLIMAParameters.

This PR has a lot of changes, but it does seem to pass all the tests. I've applied the same sort of pattern in this package as others in order to make the organization familiar to users if they dig into other packages with their own parameters.

Because there are so many changes (this has been CLIMAParameter changes in only one of many repos), it would be helpful if people could pitch in with updating the docs regarding the new handling of parameters. Maybe we can follow up with a docs fixup in a subsequent PR since all of these changes are breaking (while doc changes are not), and they need to be propagated in a quick sweep through many packages.

I've also made changes to GHA to use the latest version of julia and embraced the `import FooBar as FB` syntax, since it really helps managing scope compactly