### PR TITLE
Add compat entry for Interpolations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -9,4 +9,5 @@ DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 
 [compat]
+Interpolations = "0.13"
 julia = "1.7"


### PR DESCRIPTION
I missed adding a compat entry for Interpolations, which is needed for registering the new version.