### PR TITLE
Remove data, download using Artifacts, update API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -4,6 +4,7 @@ authors = ["Climate Modeling Alliance"]
 version = "0.3.1"
 
 [deps]
+ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 DelimitedFiles = "8bb1440f-4735-579b-a4ab-409b98df4dab"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "0.3.1"
+version = "0.4.0"
 
 [deps]
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"

--- a/docs/src/InsolationExamples.md
+++ b/docs/src/InsolationExamples.md
@@ -10,13 +10,14 @@ include("plot_diurnal_cycle.jl")
 lat, lon = [34.15, -118.14]
 date = DateTime(2020, 01, 10)
 timezone = +8 # Pacific Standard Time
-diurnal_cycle(lat, lon, date, timezone, "Pasadena_January.png")
+od = Insolation.OrbitalData()
+diurnal_cycle(lat, lon, date, od, timezone, "Pasadena_January.png")
 
 # Finland in June
 lat, lon = [66.50, 25.73]
 date = DateTime(2020, 06, 10)
 timezone = -3 # Eastern European Summer Time
-diurnal_cycle(lat, lon, date, timezone, "Finland_June.png")
+diurnal_cycle(lat, lon, date, od, timezone, "Finland_June.png")
 ```
 ![](Pasadena_January.png)
 ![](Finland_June.png)
@@ -36,8 +37,9 @@ include("plot_insolation.jl")
 γ0 = IP.obliq_epoch(param_set)
 ϖ0 = IP.lon_perihelion_epoch(param_set)
 e0 = IP.eccentricity_epoch(param_set)
+od = Insolation.OrbitalData()
 
-days, lats, F0 = calc_day_lat_insolation(365, 180, param_set)
+days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set)
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ0), rad2deg(ϖ0), e0) #hide
 plot_day_lat_insolation(days, lats, F0, "YlOrRd", title, "insol_example1.png")
 ```
@@ -56,12 +58,13 @@ include("plot_insolation.jl") # hide
 γ0 = IP.obliq_epoch(param_set) # hide
 ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
 e0 = IP.eccentricity_epoch(param_set) # hide
-days, lats, F0 = calc_day_lat_insolation(365, 180, param_set) # hide
+od = Insolation.OrbitalData()
+days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set) # hide
 
 # decrease γ to 20.0°
 param_set = create_insolation_parameters(FT, (;obliq_epoch = deg2rad(20.0)))
 γ1 = IP.obliq_epoch(param_set)
-days, lats, F2 = calc_day_lat_insolation(365, 180, param_set)
+days, lats, F2 = calc_day_lat_insolation(od, 365, 180, param_set)
 
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ1), rad2deg(ϖ0), e0) # hide
 plot_day_lat_insolation(days,lats,F2,"YlOrRd",  title, "insol_example2a.png")
@@ -84,12 +87,13 @@ include("plot_insolation.jl") # hide
 γ0 = IP.obliq_epoch(param_set) # hide
 ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
 e0 = IP.eccentricity_epoch(param_set) # hide
-days, lats, F0 = calc_day_lat_insolation(365, 180, param_set) # hide
+od = Insolation.OrbitalData()
+days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set) # hide
 
 # now change obliquity to 97.86°
 param_set = create_insolation_parameters(FT, (;obliq_epoch = deg2rad(97.86)))
 γ4 = IP.obliq_epoch(param_set)
-days, lats, F5 = calc_day_lat_insolation(365, 180, param_set)
+days, lats, F5 = calc_day_lat_insolation(od, 365, 180, param_set)
 
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ4), rad2deg(ϖ0), e0) # hide
 plot_day_lat_insolation(days,lats,F5,"YlOrRd", title, "insol_example3a.png")

--- a/docs/src/Milankovitch.md
+++ b/docs/src/Milankovitch.md
@@ -5,8 +5,9 @@
 using Insolation
 using Plots
 
+od = Insolation.OrbitalData()
 dt = collect(-500e3:100:500e3); # years
-y = hcat(collect.(orbital_params.(dt))...);
+y = hcat(collect.(orbital_params.(Ref(od), dt))...);
 ϖ, γ, e = y[1,:], y[2,:], y[3,:];
 
 p1 = plot(dt ./ (1e3), sin.(ϖ), legend=false);
@@ -31,11 +32,12 @@ include("find_equinox_perihelion_dates.jl")
 years = 1800:2200;
 days_eq = zeros(length(years));
 days_per = zeros(length(years));
+od = Insolation.OrbitalData()
 for (i,year) in enumerate(years)
-    f = (x -> zdiff(x, year))
+    f = (x -> zdiff(x, year, od))
     days_eq[i] = find_zeros(f,-30,60)[1]
 
-    f = (x -> edist(x, year))
+    f = (x -> edist(x, year, od))
     res = optimize(f,-50,50)
     days_per[i] = Optim.minimizer(res)[1]
 end
@@ -60,11 +62,11 @@ The Gregorian calendar was introduced (with leap years and leap centuries) preci
 ```@example
 using Roots
 include("find_equinox_perihelion_dates.jl")
-
+od = Insolation.OrbitalData()
 years = -50e3:100:30e3 
 days_eq = zeros(length(years)) 
 for (i,year) in enumerate(years) 
-    f = (x -> zdiff(x, year)) 
+    f = (x -> zdiff(x, year, od)) 
     days_eq[i] = find_zeros(f,-100,100)[1] 
 end 
 

--- a/docs/src/find_equinox_perihelion_dates.jl
+++ b/docs/src/find_equinox_perihelion_dates.jl
@@ -9,10 +9,10 @@ include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
 param_set = create_insolation_parameters(FT)
 
 # Difference in NH and SH zenith angles at time x in given year
-function zdiff(x, year)
+function zdiff(x, year, od)
     date = xtomarchdate(x,year)
-    theta_s, dist = daily_zenith_angle(date, -45., param_set, milankovitch=true)
-    theta_n, dist = daily_zenith_angle(date, 45., param_set, milankovitch=true)
+    theta_s, dist = daily_zenith_angle(date, od, -45., param_set, milankovitch=true)
+    theta_n, dist = daily_zenith_angle(date, od, 45., param_set, milankovitch=true)
     return theta_n - theta_s
 end
 
@@ -24,9 +24,9 @@ function xtomarchdate(x, year)
 end
 
 # Earth-Sun distance
-function edist(x, year)
+function edist(x, year, od)
     date = xtojandate(x,year)
-    _, dist = daily_zenith_angle(date, 0., param_set, milankovitch=true)
+    _, dist = daily_zenith_angle(date, od, 0., param_set, milankovitch=true)
     return dist/IP.orbit_semimaj(param_set)
 end
 

--- a/docs/src/library.md
+++ b/docs/src/library.md
@@ -9,6 +9,10 @@ Private = false
 Pages   = ["Insolation.jl"]
 ```
 
+```@docs
+Insolation.OrbitalData
+```
+
 ## Zenith Angle
 ```@autodocs
 Modules = [Insolation]

--- a/docs/src/plot_diurnal_cycle.jl
+++ b/docs/src/plot_diurnal_cycle.jl
@@ -10,7 +10,7 @@ FT = Float64
 include(joinpath(pkgdir(Insolation), "parameters", "create_parameters.jl"))
 param_set = create_insolation_parameters(FT)
 
-function diurnal_cycle(lat, lon, date, timezone, filename)
+function diurnal_cycle(lat, lon, date, od, timezone, filename)
     nhours = 1000
     hours = collect(range(0, stop = 24, length = nhours))
     insol = zeros(nhours)
@@ -19,7 +19,7 @@ function diurnal_cycle(lat, lon, date, timezone, filename)
         h = Int(round(hr + timezone))
         m = Int(round((hr + timezone - h) * 60))
         datetime = date + Dates.Hour(h) + Dates.Minute(m)
-        S, mu = solar_flux_and_cos_sza(datetime, lon, lat, param_set)
+        S, mu = solar_flux_and_cos_sza(datetime, od, lon, lat, param_set)
         insol[i] = S*mu
         sza[i] = rad2deg(acos(mu))
     end

--- a/docs/src/plot_insolation.jl
+++ b/docs/src/plot_insolation.jl
@@ -8,11 +8,12 @@ import CLIMAParameters as CP
 import Insolation.Parameters as IP
 
 """
-    calc_day_lat_insolation(n_days::I,
+    calc_day_lat_insolation(od::Insolation.OrbitalData,
+                            n_days::I,
                             n_lats::I,
                             param_set::IP.AIP) where {I<:Int}
 """
-function calc_day_lat_insolation(n_days::I,
+function calc_day_lat_insolation(od, n_days::I,
                                 n_lats::I,
                                 param_set::IP.AIP) where {I<:Int}
   d_arr = Array{I}(round.(collect(range(0, stop = 365, length = n_days))))
@@ -22,7 +23,7 @@ function calc_day_lat_insolation(n_days::I,
   for (i, d) in enumerate(d_arr)
     for (j, lat) in enumerate(l_arr)
         date = Dates.DateTime(2000,1,1) + Dates.Day(d)
-        θ, dist = daily_zenith_angle(date, lat, param_set, milankovitch=false)
+        θ, dist = daily_zenith_angle(date, od, lat, param_set, milankovitch=false)
         F_arr[i, j] = insolation(θ, dist, param_set)
     end
   end

--- a/src/Artifacts.toml
+++ b/src/Artifacts.toml
@@ -1,0 +1,2 @@
+[era-global]
+git-tree-sha1 = "4fda5e46a91c2a0cf12c9b46dad3a4189ebcfb37"

--- a/src/Insolation.jl
+++ b/src/Insolation.jl
@@ -1,6 +1,7 @@
 module Insolation
 
 using Dates, DelimitedFiles, Interpolations
+import ArtifactWrappers as AW
 
 include("Parameters.jl")
 import .Parameters as IP
@@ -8,40 +9,60 @@ const AIP = IP.AbstractInsolationParams
 
 export orbital_params
 
-mock_t_range = 1.0:1.0:10.0;
-mock_x_data = rand(10);
-const e_spline_etp = Ref(CubicSplineInterpolation(mock_t_range, mock_x_data, extrapolation_bc = NaN))
-const γ_spline_etp = Ref(CubicSplineInterpolation(mock_t_range, mock_x_data, extrapolation_bc = NaN))
-const ϖ_spline_etp = Ref(CubicSplineInterpolation(mock_t_range, mock_x_data, extrapolation_bc = NaN))
-function __init__()
-    datapath = joinpath(@__DIR__, "../src/data/", "INSOL.LA2004.BTL.csv");
-    x, _ = readdlm(datapath, ',', Float64, header=true);
-    t_range = x[1,1]*1e3 : 1e3 : x[end,1]*1e3; # array of every 1 kyr to range of years
-    e_spline_etp[] = CubicSplineInterpolation(t_range, x[:,2], extrapolation_bc = NaN);
-    γ_spline_etp[] = CubicSplineInterpolation(t_range, x[:,3], extrapolation_bc = NaN);
-    ϖ_spline_etp[] = CubicSplineInterpolation(t_range, x[:,4], extrapolation_bc = NaN);
-end
-function e_spline(args...)
-    return e_spline_etp[](args...)
-end
-function γ_spline(args...)
-    return γ_spline_etp[](args...)
-end
-function ϖ_spline(args...)
-    return ϖ_spline_etp[](args...)
+function orbital_parameters_dataset_path()
+    era_dataset = AW.ArtifactWrapper(
+        @__DIR__,
+        "era-global",
+        AW.ArtifactFile[AW.ArtifactFile(
+            url = "https://caltech.box.com/shared/static/3y02smnlxhgwednm3eho7lve2xhq1n7r.csv",
+            filename = "INSOL.LA2004.BTL.csv",
+        ),],
+    )
+    return AW.get_data_folder(era_dataset)
 end
 
 """
-    orbital_params(dt::FT) where {FT <: Real}
+    OrbitalData
 
-This function returns the orbital parameters (ϖ, γ, e) at dt (years) since J2000 epoch.
-Data are read from file and interpolation functions are created in __init__() method.
-The functions are stored as global variables that are used inside Insolation.jl.
 The parameters vary due to Milankovitch cycles. 
-Orbital parameters from the Laskar 2004 paper are in the "src/data/INSOL.LA2004.BTL.csv" file.
+
+Orbital parameters from the Laskar 2004 paper are
+lazily downloaded from Caltech Box to the
+`orbital_parameters_dataset_path()` path.
 """
-function orbital_params(dt::FT) where {FT <: Real}
-    return ϖ_spline(dt), γ_spline(dt), e_spline(dt)
+struct OrbitalData{E, G, O}
+    e_spline_etp::E
+    γ_spline_etp::G
+    ϖ_spline_etp::O
+    function OrbitalData()
+        datapath = joinpath(orbital_parameters_dataset_path(), "INSOL.LA2004.BTL.csv");
+        x, _ = readdlm(datapath, ',', Float64, header=true);
+        t_range = x[1,1]*1e3 : 1e3 : x[end,1]*1e3; # array of every 1 kyr to range of years
+        e_spline_etp = CubicSplineInterpolation(t_range, x[:,2], extrapolation_bc = NaN);
+        γ_spline_etp = CubicSplineInterpolation(t_range, x[:,3], extrapolation_bc = NaN);
+        ϖ_spline_etp = CubicSplineInterpolation(t_range, x[:,4], extrapolation_bc = NaN);
+
+        E = typeof(e_spline_etp)
+        G = typeof(γ_spline_etp)
+        O = typeof(ϖ_spline_etp)
+        return new{E,G,O}(e_spline_etp,γ_spline_etp,ϖ_spline_etp)
+    end
+end
+
+e_spline(od, args...) = od.e_spline_etp(args...)
+γ_spline(od, args...) = od.γ_spline_etp(args...)
+ϖ_spline(od, args...) = od.ϖ_spline_etp(args...)
+
+"""
+    orbital_params(od::OrbitalData, dt::FT) where {FT <: Real}
+
+Parameters are interpolated from the values given in the
+Laskar 2004 dataset using a cubic spline interpolation.
+
+See [`OrbitalData`](@ref).
+"""
+function orbital_params(od::OrbitalData, dt::FT) where {FT <: Real}
+    return ϖ_spline(od, dt), γ_spline(od, dt), e_spline(od, dt)
 end
 
 include("ZenithAngleCalc.jl")

--- a/src/InsolationCalc.jl
+++ b/src/InsolationCalc.jl
@@ -22,6 +22,7 @@ end
 
 """
     solar_flux_and_cos_sza(date::DateTime,
+                      od::OrbitalData,
                       longitude::FT,
                       latitude::FT,
                       param_set::IP.AIP) where {FT <: Real}
@@ -32,13 +33,14 @@ and cos(solar zenith angle) for input to RRTMGP.jl
 param_set is an AbstractParameterSet from CLIMAParameters.jl.
 """
 function solar_flux_and_cos_sza(date::DateTime,
+                           od::OrbitalData,
                            longitude::FT,
                            latitude::FT,
                            param_set::IP.AIP) where {FT <: Real}
     S0::FT = IP.tot_solar_irrad(param_set)
     d0::FT = IP.orbit_semimaj(param_set)
     # θ = solar zenith angle, ζ = solar azimuth angle, d = earth-sun distance
-    θ, ζ, d = instantaneous_zenith_angle(date, longitude, latitude, param_set)
+    θ, ζ, d = instantaneous_zenith_angle(date, od, longitude, latitude, param_set)
     # set max. zenith angle to π/2, insolation should not be negative
     if θ > FT(π)/2
         θ = FT(π)/2

--- a/src/ZenithAngleCalc.jl
+++ b/src/ZenithAngleCalc.jl
@@ -17,6 +17,7 @@ end
 # calculate the distance, declination, and hour angle (at lon=0)
 function distance_declination_hourangle(::Type{FT},
                                         date::DateTime,
+                                        od::OrbitalData,
                                         param_set::IP.AIP,
                                         eot_correction::Bool,
                                         milankovitch::Bool) where {FT <: Real}
@@ -37,9 +38,9 @@ function distance_declination_hourangle(::Type{FT},
 
     # calculate orbital parameters or take values at J2000
     if milankovitch
-        ϖ = FT(ϖ_spline(Δt_years));
-        γ = FT(γ_spline(Δt_years));
-        e = FT(e_spline(Δt_years));
+        ϖ = FT(ϖ_spline(od, Δt_years));
+        γ = FT(γ_spline(od, Δt_years));
+        e = FT(e_spline(od, Δt_years));
     else
         ϖ = FT(IP.lon_perihelion_epoch(param_set));
         γ = FT(IP.obliq_epoch(param_set));
@@ -72,6 +73,7 @@ end
 
 """
     instantaneous_zenith_angle(date::DateTime,
+                               od::OrbitalData,
                                longitude::FT,
                                latitude::FT,
                                param_set::IP.AIP;
@@ -92,6 +94,7 @@ when set to true the orbital parameters are calculated for the given DateTime
 when set to false the orbital parameters at the J2000 epoch from CLIMAParameters are used.
 """
 function instantaneous_zenith_angle(date::DateTime,
+                                    od::OrbitalData,
                                     longitude::FT,
                                     latitude::FT,
                                     param_set::IP.AIP;
@@ -100,7 +103,7 @@ function instantaneous_zenith_angle(date::DateTime,
     λ = deg2rad(longitude)
     ϕ = deg2rad(latitude)
 
-    d, δ, η_UTC = distance_declination_hourangle(FT, date, param_set, eot_correction, milankovitch)
+    d, δ, η_UTC = distance_declination_hourangle(FT, date, od, param_set, eot_correction, milankovitch)
 
     # hour angle
     η = mod(η_UTC + λ, FT(2π))
@@ -117,6 +120,7 @@ end
 
 """
     daily_zenith_angle(date::DateTime,
+                       od::OrbitalData,
                        latitude::FT,
                        param_set::IP.AIP;
                        eot_correction::Bool=true,
@@ -136,13 +140,14 @@ when set to true the orbital parameters are calculated for the given DateTime,
 when set to false the orbital parameters at the J2000 epoch from CLIMAParameters are used.
 """
 function daily_zenith_angle(date::DateTime,
+                            od::OrbitalData,
                             latitude::FT,
                             param_set::IP.AIP;
                             eot_correction::Bool=true,
                             milankovitch::Bool=true) where {FT <: Real}
     ϕ = deg2rad(latitude)
 
-    d, δ, _ = distance_declination_hourangle(FT, date, param_set, eot_correction, milankovitch)
+    d, δ, _ = distance_declination_hourangle(FT, date, od, param_set, eot_correction, milankovitch)
 
     # sunrise/sunset angle
     T = tan(ϕ) * tan(δ)

--- a/test/test_equinox.jl
+++ b/test/test_equinox.jl
@@ -1,8 +1,8 @@
 # Difference in NH and SH zenith angles at time x in given year
-function zdiff(x, year)
+function zdiff(x, year, od)
     date = xtomarchdate(x,year)
-    theta_s, dist = daily_zenith_angle(date, FT(-45), param_set)
-    theta_n, dist = daily_zenith_angle(date, FT(45), param_set)
+    theta_s, dist = daily_zenith_angle(date, od, FT(-45), param_set)
+    theta_n, dist = daily_zenith_angle(date, od, FT(45), param_set)
     return theta_n - theta_s
 end
 
@@ -13,9 +13,10 @@ function xtomarchdate(x, year)
     return basedate + deltat
 end
 
+od = Insolation.OrbitalData()
 days = zeros(length(1900:2100))
 for (i,year) in enumerate(1900:2100)
-    f = (x -> zdiff(x, year))
+    f = (x -> zdiff(x, year, od))
     days[i] = find_zeros(f,1.,30)[1]
 end
 

--- a/test/test_insolation.jl
+++ b/test/test_insolation.jl
@@ -2,36 +2,37 @@ atol = 1e-4
 rtol = 1e-2
 rtol_insol = 0.1
 
+od = Insolation.OrbitalData()
 ## Test zero insolation at night
 # sunrise at equator
 date = Dates.DateTime(2020, 1, 1, 6, 0, 0)
 lon, lat = [FT(0.0), FT(0.0)]
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
-S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
+S, mu = solar_flux_and_cos_sza(date, od, lon, lat, param_set)
 @test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
 # polar night NH 1
 date = Dates.DateTime(2020, 12, 20, 11, 0, 0)
 lon, lat = [FT(0.0), FT(80.0)]
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
-S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
+S, mu = solar_flux_and_cos_sza(date, od, lon, lat, param_set)
 @test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
 # polar night NH 2
 date = Dates.DateTime(2020, 12, 20, 23, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 F = insolation(sza, d, param_set)
 @test F ≈ 0.0 atol=atol
 
-S, mu = solar_flux_and_cos_sza(date, lon, lat, param_set)
+S, mu = solar_flux_and_cos_sza(date, od, lon, lat, param_set)
 @test S ≈ IP.tot_solar_irrad(param_set) rtol=rtol_insol
 @test mu ≈ 0.0 atol=atol
 
@@ -41,7 +42,7 @@ date = Dates.DateTime(2021, 3, 20, 9, 37, 0) # vernal equinox 2021
 l_arr = FT.(collect(range(-90, stop = 90, length = nlats)))
 F_arr = zeros(nlats)
 for (i, lat) in enumerate(l_arr)
-    θ, dist = daily_zenith_angle(date, lat, param_set)
+    θ, dist = daily_zenith_angle(date, od, lat, param_set)
     F_arr[i] = insolation(θ, dist, param_set)
 end
 F_NH = sort(F_arr[l_arr .>= 0])
@@ -57,7 +58,7 @@ F_arr = zeros(ndays, nlats)
 for (i, d) in enumerate(d_arr)
     for (j, lat) in enumerate(l_arr)
         datei = Dates.DateTime(2000,1,1) + Dates.Day(d)
-        θ, dist = daily_zenith_angle(datei, lat, param_set)
+        θ, dist = daily_zenith_angle(datei, od, lat, param_set)
         F_arr[i, j] = insolation(θ, dist, param_set)
     end
 end
@@ -74,7 +75,7 @@ param_set = create_insolation_parameters(FT, (; lon_perihelion_epoch = ϖ0 + π)
 for (i, d) in enumerate(d_arr)
     for (j, lat) in enumerate(l_arr)
         datei = Dates.DateTime(2000,1,1) + Dates.Day(d)
-        θ, dist = daily_zenith_angle(datei, lat, param_set)
+        θ, dist = daily_zenith_angle(datei, od, lat, param_set)
         F_arr[i, j] = insolation(θ, dist, param_set)
     end
 end

--- a/test/test_orbit_param.jl
+++ b/test/test_orbit_param.jl
@@ -1,10 +1,10 @@
 rtol = 1e-2
+od = Insolation.OrbitalData()
+@test mod(Insolation.ϖ_spline(od, 0.0),2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
+@test Insolation.γ_spline(od, 0.0) ≈ IP.obliq_epoch(param_set) rtol=rtol
+@test Insolation.e_spline(od, 0.0) ≈ IP.eccentricity_epoch(param_set) rtol=rtol
 
-@test mod(Insolation.ϖ_spline(0.0),2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
-@test Insolation.γ_spline(0.0) ≈ IP.obliq_epoch(param_set) rtol=rtol
-@test Insolation.e_spline(0.0) ≈ IP.eccentricity_epoch(param_set) rtol=rtol
-
-ϖ0, γ0, e0 = orbital_params(0.0)
+ϖ0, γ0, e0 = orbital_params(od, 0.0)
 @test mod(ϖ0,2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
 @test γ0 ≈ IP.obliq_epoch(param_set) rtol=rtol
 @test e0 ≈ IP.eccentricity_epoch(param_set) rtol=rtol

--- a/test/test_perihelion.jl
+++ b/test/test_perihelion.jl
@@ -7,16 +7,17 @@ function xtojandate(x, year)
 end
 
 # Earth-Sun distance
-function edist(x, year)
+function edist(x, year, od)
     date = xtojandate(x,year)
-    _, dist = daily_zenith_angle(date, FT(0), param_set)
+    _, dist = daily_zenith_angle(date, od, FT(0), param_set)
     return dist/IP.orbit_semimaj(param_set)
 end
 
 years = 1900:2100
 days = zeros(length(years))
+od = Insolation.OrbitalData()
 for (i,year) in enumerate(years)
-    f = (x -> edist(x, year))
+    f = (x -> edist(x, year, od))
     res = optimize(f,1.,30)
     days[i] = Optim.minimizer(res)[1]
 end

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,8 +1,11 @@
 date = Dates.DateTime(2020, 2, 20, 11, 11, 0)
 lon, lat = [FT(80.0), FT(20.0)]
 
+od = Insolation.OrbitalData()
+
 sza, azi, d = instantaneous_zenith_angle(
     date,
+    od,
     lon,
     lat,
     param_set,
@@ -17,6 +20,7 @@ F = insolation(sza, d, param_set)
 
 sza, azi, d = instantaneous_zenith_angle(
     date,
+    od,
     lon,
     lat,
     param_set,
@@ -31,6 +35,7 @@ F = insolation(sza, d, param_set)
 
 sza, azi, d = instantaneous_zenith_angle(
     date,
+    od,
     lon,
     lat,
     param_set,
@@ -45,6 +50,7 @@ F = insolation(sza, d, param_set)
 
 sza, azi, d = instantaneous_zenith_angle(
     date,
+    od,
     lon,
     lat,
     param_set,

--- a/test/test_zenith_angle.jl
+++ b/test/test_zenith_angle.jl
@@ -1,55 +1,55 @@
 rtol = 1e-2
-
+od = Insolation.OrbitalData()
 # sunrise at equator
 date = Dates.DateTime(2020, 2, 20, 6, 11, 0)
 lon, lat = [FT(0.0), FT(0.0)]
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza ≈ π/2 rtol=rtol
 
 # solar noon at equator
 date = Dates.DateTime(2020, 2, 20, 12, 14, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test azi ≈ 3π/2 rtol=rtol
 
 # sunset at equator
 date = Dates.DateTime(2020, 2, 20, 18, 17, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza ≈ π/2 rtol=rtol
 
 # solar noon at equator, eot correction = false
 date = Dates.DateTime(2020, 2, 20, 12, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set; eot_correction=false)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set; eot_correction=false)
 @test azi ≈ 3π/2 rtol=rtol
 
 # sunset at equator, eot correction = false
 date = Dates.DateTime(2020, 2, 20, 18, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set; eot_correction=false)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set; eot_correction=false)
 @test sza ≈ π/2 rtol=rtol
 
 ## Test Polar Night
 # polar night NH 1
 date = Dates.DateTime(2020, 12, 20, 11, 0, 0)
 lon, lat = [FT(0.0), FT(80.0)]
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza > π/2
 
 # polar night NH 2
 date = Dates.DateTime(2020, 12, 20, 23, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza > π/2
 
 # polar night SH 1
 date = Dates.DateTime(2020, 6, 20, 11, 0, 0)
 lon, lat = [FT(0.0), FT(-80.0)]
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza > π/2
 
 # polar night SH 2
 date = Dates.DateTime(2020, 6, 20, 23, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test sza > π/2
 
 ## Test Distance
 date = Dates.DateTime(2000, 3, 22, 0, 0, 0)
-sza, azi, d = instantaneous_zenith_angle(date, lon, lat, param_set)
+sza, azi, d = instantaneous_zenith_angle(date, od, lon, lat, param_set)
 @test d ≈ IP.orbit_semimaj(param_set) rtol=rtol


### PR DESCRIPTION
Insolation is one of the most expensive packages to load (xref: https://github.com/SciML/ExponentialUtilities.jl/issues/128#issue-1696750512).

This PR removes the data from the repo, and instead lazily downloads the data via Artifacts (if used). The API is correspondingly updated. These are breaking changes but I think it makes the code more modular since we remove the module constants, and users don't pay the cost of interpolating all of this data unless they need it.

This PR improves package load times:

Main:
```julia
julia> @time using Insolation
[ Info: Precompiling Insolation [e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8]
  4.247356 seconds (9.36 M allocations: 550.601 MiB, 1.79% gc time, 22.78% compilation time: 0% of which was recompilation)
```

This PR:
```julia
julia> @time using Insolation
  0.569632 seconds (2.52 M allocations: 185.921 MiB, 2.25% gc time, 1.57% compilation time: 8% of which was recompilation)
```
