### PR TITLE
Fix handling of Artifacts for users without file permissions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "0.4.1"
+version = "0.5.0"
 
 [deps]
 ArtifactWrappers = "a14bc488-3040-4b00-9dc1-f6467924858a"

--- a/data/Artifacts.toml
+++ b/data/Artifacts.toml
@@ -1,2 +1,2 @@
-[era-global]
+[orb_params_dataset]
 git-tree-sha1 = "4fda5e46a91c2a0cf12c9b46dad3a4189ebcfb37"

--- a/docs/src/InsolationExamples.md
+++ b/docs/src/InsolationExamples.md
@@ -10,7 +10,7 @@ include("plot_diurnal_cycle.jl")
 lat, lon = [34.15, -118.14]
 date = DateTime(2020, 01, 10)
 timezone = +8 # Pacific Standard Time
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 diurnal_cycle(lat, lon, date, od, timezone, "Pasadena_January.png")
 
 # Finland in June
@@ -37,7 +37,7 @@ include("plot_insolation.jl")
 γ0 = IP.obliq_epoch(param_set)
 ϖ0 = IP.lon_perihelion_epoch(param_set)
 e0 = IP.eccentricity_epoch(param_set)
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 
 days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set)
 title = format("γ = {:.2f}°, ϖ = {:.2f}°, e = {:.2f}", rad2deg(γ0), rad2deg(ϖ0), e0) #hide
@@ -58,7 +58,7 @@ include("plot_insolation.jl") # hide
 γ0 = IP.obliq_epoch(param_set) # hide
 ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
 e0 = IP.eccentricity_epoch(param_set) # hide
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set) # hide
 
 # decrease γ to 20.0°
@@ -87,7 +87,7 @@ include("plot_insolation.jl") # hide
 γ0 = IP.obliq_epoch(param_set) # hide
 ϖ0 = IP.lon_perihelion_epoch(param_set) # hide
 e0 = IP.eccentricity_epoch(param_set) # hide
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 days, lats, F0 = calc_day_lat_insolation(od, 365, 180, param_set) # hide
 
 # now change obliquity to 97.86°

--- a/docs/src/Milankovitch.md
+++ b/docs/src/Milankovitch.md
@@ -5,7 +5,7 @@
 using Insolation
 using Plots
 
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 dt = collect(-500e3:100:500e3); # years
 y = hcat(collect.(orbital_params.(Ref(od), dt))...);
 ϖ, γ, e = y[1,:], y[2,:], y[3,:];
@@ -32,7 +32,7 @@ include("find_equinox_perihelion_dates.jl")
 years = 1800:2200;
 days_eq = zeros(length(years));
 days_per = zeros(length(years));
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 for (i,year) in enumerate(years)
     f = (x -> zdiff(x, year, od))
     days_eq[i] = find_zeros(f,-30,60)[1]
@@ -62,7 +62,7 @@ The Gregorian calendar was introduced (with leap years and leap centuries) preci
 ```@example
 using Roots
 include("find_equinox_perihelion_dates.jl")
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 years = -50e3:100:30e3 
 days_eq = zeros(length(years)) 
 for (i,year) in enumerate(years) 

--- a/src/Insolation.jl
+++ b/src/Insolation.jl
@@ -9,16 +9,19 @@ const AIP = IP.AbstractInsolationParams
 
 export orbital_params
 
-function orbital_parameters_dataset_path()
-    era_dataset = AW.ArtifactWrapper(
-        @__DIR__,
-        "era-global",
+#= For test/docs use only =#
+datadir() = joinpath(dirname(@__DIR__), "data")
+
+function orbital_parameters_dataset_path(artifact_dir)
+    orb_params_dataset = AW.ArtifactWrapper(
+        artifact_dir,
+        "orb_params_dataset",
         AW.ArtifactFile[AW.ArtifactFile(
             url = "https://caltech.box.com/shared/static/3y02smnlxhgwednm3eho7lve2xhq1n7r.csv",
             filename = "INSOL.LA2004.BTL.csv",
         ),],
     )
-    return AW.get_data_folder(era_dataset)
+    return AW.get_data_folder(orb_params_dataset)
 end
 
 """
@@ -28,14 +31,16 @@ The parameters vary due to Milankovitch cycles.
 
 Orbital parameters from the Laskar 2004 paper are
 lazily downloaded from Caltech Box to the
-`orbital_parameters_dataset_path()` path.
+`orbital_parameters_dataset_path(artifact_dir)` path
+where `artifact_dir` is the path and filename to save
+the artifacts toml file.
 """
 struct OrbitalData{E, G, O}
     e_spline_etp::E
     γ_spline_etp::G
     ϖ_spline_etp::O
-    function OrbitalData()
-        datapath = joinpath(orbital_parameters_dataset_path(), "INSOL.LA2004.BTL.csv");
+    function OrbitalData(artifact_dir)
+        datapath = joinpath(orbital_parameters_dataset_path(artifact_dir), "INSOL.LA2004.BTL.csv");
         x, _ = readdlm(datapath, ',', Float64, header=true);
         t_range = x[1,1]*1e3 : 1e3 : x[end,1]*1e3; # array of every 1 kyr to range of years
         e_spline_etp = CubicSplineInterpolation(t_range, x[:,2], extrapolation_bc = NaN);

--- a/test/test_equinox.jl
+++ b/test/test_equinox.jl
@@ -13,7 +13,7 @@ function xtomarchdate(x, year)
     return basedate + deltat
 end
 
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 days = zeros(length(1900:2100))
 for (i,year) in enumerate(1900:2100)
     f = (x -> zdiff(x, year, od))

--- a/test/test_insolation.jl
+++ b/test/test_insolation.jl
@@ -2,7 +2,7 @@ atol = 1e-4
 rtol = 1e-2
 rtol_insol = 0.1
 
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 ## Test zero insolation at night
 # sunrise at equator
 date = Dates.DateTime(2020, 1, 1, 6, 0, 0)

--- a/test/test_orbit_param.jl
+++ b/test/test_orbit_param.jl
@@ -1,5 +1,5 @@
 rtol = 1e-2
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 @test mod(Insolation.ϖ_spline(od, 0.0),2π) ≈ mod(IP.lon_perihelion_epoch(param_set),2π) rtol=rtol
 @test Insolation.γ_spline(od, 0.0) ≈ IP.obliq_epoch(param_set) rtol=rtol
 @test Insolation.e_spline(od, 0.0) ≈ IP.eccentricity_epoch(param_set) rtol=rtol

--- a/test/test_perihelion.jl
+++ b/test/test_perihelion.jl
@@ -15,7 +15,7 @@ end
 
 years = 1900:2100
 days = zeros(length(years))
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 for (i,year) in enumerate(years)
     f = (x -> edist(x, year, od))
     res = optimize(f,1.,30)

--- a/test/test_types.jl
+++ b/test/test_types.jl
@@ -1,7 +1,7 @@
 date = Dates.DateTime(2020, 2, 20, 11, 11, 0)
 lon, lat = [FT(80.0), FT(20.0)]
 
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 
 sza, azi, d = instantaneous_zenith_angle(
     date,

--- a/test/test_zenith_angle.jl
+++ b/test/test_zenith_angle.jl
@@ -1,5 +1,5 @@
 rtol = 1e-2
-od = Insolation.OrbitalData()
+od = Insolation.OrbitalData(Insolation.datadir())
 # sunrise at equator
 date = Dates.DateTime(2020, 2, 20, 6, 11, 0)
 lon, lat = [FT(0.0), FT(0.0)]


### PR DESCRIPTION
This seems like the simplest solution to fix https://github.com/CliMA/ArtifactWrappers.jl/issues/12. I thought about making `artifact_dir ` optional, but then users can run into this problem even if they are simply not developing Insolation.jl, too.

This PR should make Insolation artifacts more useable by dependents.

We haven't run into this issue in ClimaAtmos, but I suspect that that is because we have file permissions on central, which do not exist in the GHA runners.