### PR TITLE
Add julia 1.9 and 1.10 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         version:
           - '1.7.3'
+          - '1.9'
+          - '~1.10.0-rc1'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         version:
           - '1.7.3'
           - '1.9'
-          - '~1.10.0-rc1'
+          - '1.10'
         os:
           - ubuntu-latest
           - macOS-latest


### PR DESCRIPTION
Insolations.jl only ran against 1.7.3, I added two more recent versions.
