### PR TITLE
Bump insolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Insolation"
 uuid = "e98cc03f-d57e-4e3c-b70c-8d51efe9e0d8"
 authors = ["Climate Modeling Alliance"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
Inolation.jl 0.8 was blocking the update of Interpolations.jl to 0.15 in downstream packages. This will unblock it.